### PR TITLE
Initial test scaffolding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.11.0
+
+      - name: Run tests
+        # retry to get around "resource busy"
+        # and other transient failures
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 1
+          max_attempts: 3
+          command: devbox run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .gren
 app
+app-test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+app: gren.json $(shell find src -name "*.gren")
+	gren make src/Main.gren
+
+app-test: gren.json $(shell find src/Test -name "*.gren")
+	gren make src/Test/Main.gren --output=app-test
+
+.PHONY: server
+server: app
+	node app
+
+.PHONY: test
+test: app-test
+	node app-test

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ Once task ports land (25S?), switch to sqlite via ports with litestream for back
 ## Local Development
 
 This project uses [devbox](https://www.jetify.com/devbox).
-If you don't want to use devbox, you can find a list of the requried dependencies and the commands for running the server in devbox.json.
 
-You can run the server with `devbox run server`.
+You can run the server with `devbox services up`
+
+To run in the background, run `devbox services up -b` and stop with `devbox services stop`
+
+Run tests with `devbox run test`
 
 ## Open Questions
 

--- a/devbox.json
+++ b/devbox.json
@@ -9,10 +9,7 @@
     ],
     "scripts": {
       "test": [
-        "echo \"Error: no test specified\" && exit 1"
-      ],
-      "server": [
-        "gren make src/Main.gren && node app"
+        "./test.sh"
       ]
     }
   }

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.6/.schema/devbox.schema.json",
   "packages": [
-    "github:gren-lang/nix/0.5.3",
+    "github:gren-lang/nix/0.5.4",
     "nodejs@20"
   ],
   "shell": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -4,8 +4,8 @@
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
       "resolved": "github:NixOS/nixpkgs/3549532663732bfd89993204d40543e9edaec4f2?lastModified=1742272065&narHash=sha256-ud8vcSzJsZ%2FCK%2Br8%2Fv0lyf4yUntVmDq6Z0A41ODfWbE%3D"
     },
-    "github:gren-lang/nix/0.5.3": {
-      "resolved": "github:gren-lang/nix/7ccce05f4a1e7fa390bad019d40f2de49ff8a1a5?lastModified=1739404620&narHash=sha256-WR1mPvRZKoRQwjIOsNoJFaesJ595XyG9uXv%2BLGBEjiI%3D"
+    "github:gren-lang/nix/0.5.4": {
+      "resolved": "github:gren-lang/nix/35601dd5c34adce2bbc6740ccc19a55078eb27be?lastModified=1742812541&narHash=sha256-iJcZAefSQM67bMRlJPEXT0%2FkVUoEmcr9NYTUPLoAO%2FE%3D"
     },
     "nodejs@20": {
       "last_modified": "2025-02-12T00:10:52Z",

--- a/gren.json
+++ b/gren.json
@@ -7,10 +7,13 @@
     "gren-version": "0.5.3",
     "dependencies": {
         "direct": {
+            "blaix/gren-effectful-tests-node": "4.1.0",
             "gren-lang/core": "6.0.1",
-            "gren-lang/node": "5.0.2"
+            "gren-lang/node": "5.0.2",
+            "gren-lang/test": "4.1.0"
         },
         "indirect": {
+            "gren-lang/test-runner-node": "6.0.0",
             "gren-lang/url": "5.0.0"
         }
     }

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -1,0 +1,6 @@
+# process-compose
+version: "0.5"
+
+processes:
+  server:
+   command: make server

--- a/src/Test/E2E.gren
+++ b/src/Test/E2E.gren
@@ -1,0 +1,11 @@
+module Test.E2E exposing (tests)
+
+import Expect
+import Test.Runner.Effectful exposing (Test, test)
+
+
+tests : Array Test
+tests =
+    [ test "Has tests" <| \_ ->
+        Expect.equal True True
+    ]

--- a/src/Test/Main.gren
+++ b/src/Test/Main.gren
@@ -1,0 +1,17 @@
+module Test.Main exposing (main)
+
+import Expect
+import Node
+import Test
+import Test.E2E
+import Test.Runner.Effectful as Effectful
+import Test.Unit
+
+main : Effectful.Program a
+main =
+    Node.defineSimpleProgram <| \env ->
+        Effectful.run env <|
+            Effectful.concat
+                [ Effectful.wrap <| Test.describe "Unit tests" Test.Unit.tests
+                , Effectful.describe "E2E tests" Test.E2E.tests
+                ]

--- a/src/Test/Unit.gren
+++ b/src/Test/Unit.gren
@@ -1,0 +1,12 @@
+module Test.Unit exposing (tests)
+
+import Expect
+import Test exposing (Test, test)
+
+
+tests : Array Test
+tests =
+    [ test "Has tests" <| \_ ->
+        Expect.equal True True
+    ]
+

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+devbox services up -b && make test
+devbox services stop


### PR DESCRIPTION
- Bump to Gren 0.5.4 to fix package install command
- Move server startup to a devbox process. This makes it easier to run in the background for the E2E tests (see `test.sh`).
- Run full test suite with effectful test runner, but keep unit and effectful tests in separate modules.