### PR TITLE
Only run npm install if things changed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ dist/test: dist/app
 
 node_modules: package.json package-lock.json
 	npm install
+	touch -m node_modules
 
 .PHONY: db
 db: node_modules


### PR DESCRIPTION
Because Make make compares modification date of the target vs the dependencies, npm install was always running even if nothing changed (since the target is a directory). This updates the modification date of the `node_modules` directory target after npm install runs so it won't run again unless the dependencies (`package*`) get modified.