### PR TITLE
DELETEME: show server logs after test output.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,5 @@ jobs:
           timeout_minutes: 1
           max_attempts: 3
           command: devbox run test
+        env:
+          POSTMARK_SERVER_TOKEN: ${{ vars.POSTMARK_SERVER_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 db/*.db*
 dist/app
 dist/test
+logs/
 node_modules

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -7,6 +7,7 @@ processes:
     ready_log_line: "Web Service listening"
   server:
     command: make server
+    log_location: ./logs/server.log
     depends_on:
       db:
         condition: process_log_ready

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,4 +12,8 @@ test_exit=$?
 # shutdown backgrounded app
 devbox services stop
 
+# dump server logs for debugging
+echo "=== SERVER LOGS ==="
+cat ./logs/server.log
+
 exit $test_exit

--- a/src/Route/Error.gren
+++ b/src/Route/Error.gren
@@ -5,6 +5,7 @@ module Route.Error exposing
     )
 
 
+import Log
 import Route
 import Task exposing (Task)
 
@@ -28,6 +29,7 @@ invalidRequestData response message =
 serverError : Route.Response -> String -> Task Never Route.Response
 serverError response message =
     response
+        |> Route.log (Log.Error message)
         |> Route.setStatus 500
         |> Route.setBody message
         |> Task.succeed


### PR DESCRIPTION
Need to debug why tests are failing in the github action. This is not the ideal way to do this, but since we are moving to pure nix soon I don't want to put effort into the right way for this devbox/process-compose specific setup.