### PR TITLE
Fix test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,5 @@ jobs:
           timeout_minutes: 1
           max_attempts: 3
           command: devbox run test
+        env:
+          POSTMARK_SERVER_TOKEN: ${{ vars.POSTMARK_SERVER_TOKEN }}

--- a/src/Route/Error.gren
+++ b/src/Route/Error.gren
@@ -5,6 +5,7 @@ module Route.Error exposing
     )
 
 
+import Log
 import Route
 import Task exposing (Task)
 
@@ -28,6 +29,7 @@ invalidRequestData response message =
 serverError : Route.Response -> String -> Task Never Route.Response
 serverError response message =
     response
+        |> Route.log (Log.Error message)
         |> Route.setStatus 500
         |> Route.setBody message
         |> Task.succeed


### PR DESCRIPTION
Simply setting an environment variable in the settings for the environment that a github action runs in does NOT make it available to the processes in that action, you have to pass them through like this.